### PR TITLE
Clipping table overrun fix.

### DIFF
--- a/main/amy/amy.c
+++ b/main/amy/amy.c
@@ -819,11 +819,11 @@ int16_t * fill_audio_buffer_task() {
     	} else {
             uintval = (int)(-fsample);
 	    }
-        if (uintval > LIN_MAX) {
-    	    if (uintval > NONLIN_MAX) {
+        if (uintval >= FIRSTNON_LIN) {
+            if (uintval >= FIRST_HARDCLIP) {
                 uintval = SAMPLE_MAX;
             } else {
-                uintval = clipping_lookup_table[uintval - LIN_MAX];
+                uintval = clipping_lookup_table[uintval - FIRST_NONLIN];
             }
         }
 	    int16_t sample;

--- a/main/amy/clipping_lookup_table.h
+++ b/main/amy/clipping_lookup_table.h
@@ -1,8 +1,13 @@
-// Automatically generated.
-// Clipping lookup table
-#define LIN_MAX 29491
+// Automatically generated, then edited by hand to use better names.
+// Clipping lookup table.
+
+// Sample value at which we start reading from table.
+#define FIRST_NONLIN 29491
+// Table length.
 #define NONLIN_RANGE 4915
-#define NONLIN_MAX (LIN_MAX + NONLIN_RANGE)
+// First sample value beyond end of table (just clip to max).
+#define FIRST_HARDCLIP (LIN_MAX + NONLIN_RANGE)
+// The transition curve table.
 const uint16_t clipping_lookup_table[NONLIN_RANGE] = {
 29491,29491,29492,29493,29494,29495,29496,29497,
 29498,29499,29500,29501,29502,29503,29504,29505,
@@ -618,5 +623,5 @@ const uint16_t clipping_lookup_table[NONLIN_RANGE] = {
 32767,32767,32767,32767,32767,32767,32767,32767,
 32767,32767,32767,32767,32767,32767,32767,32767,
 32767,32767,32767,32767,32767,32767,32767,32767,
-32767,32767,32767,
+32767,32767,32767
 };


### PR DESCRIPTION
Good ears and attention to detail.  Luckily, capturing the waveform (via Soundflower and Audacity) helpfully showed that it occurred just as the waveform went into hard clip, pointing to the problem.