### PR TITLE
Add docker-based build environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/ubuntu:22.10
+
+RUN apt-get -qq update -y
+RUN DEBIAN_FRONTEND=noninteractive \
+       apt-get install -y --no-install-recommends \
+            build-essential \
+            python3-pip \
+            cmake \
+            git \
+            libusb-1.0.0-dev \
+            vim
+
+RUN git clone -b v4.4 --depth 1 --recursive https://github.com/espressif/esp-idf.git /esp-idf
+WORKDIR /esp-idf
+RUN ./install.sh esp32

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,38 @@
+SRC_DIR=`pwd`/../
+BUILD_DIR=/build
+PORT?=/dev/ttyUSB0
+
+all:
+	@echo "Build targets: "
+	@echo "build-docker			Build an image for building tools with Docker"
+	@echo "build    			Build the Alles firmware in the Docker environment"
+	@echo "flash    			Flash an Alles device. Try 'PORT=/dev/xxx make flash' to specify a serial device"
+	@echo "run				(for debugging) Run a shell using the above image with Docker"
+
+build-docker:
+	docker build -t alles-builder -f Dockerfile .
+
+build:
+	docker run \
+        --rm \
+		--mount type=bind,source=${SRC_DIR},target=${BUILD_DIR} \
+		-w ${BUILD_DIR} \
+		-it alles-builder \
+        /usr/bin/bash -c ". /esp-idf/export.sh; idf.py fullclean build"
+
+flash: 
+	docker run \
+        --rm \
+		--mount type=bind,source=${SRC_DIR},target=${BUILD_DIR} \
+        --device=${PORT} \
+		-w ${BUILD_DIR} \
+		-it alles-builder \
+        /usr/bin/bash -c ". /esp-idf/export.sh; idf.py flash -p ${PORT}"
+run:
+	docker run \
+		--rm \
+		--mount type=bind,source=${SRC_DIR},target=${BUILD_DIR} \
+		-w ${BUILD_DIR} \
+		-it alles-builder \
+		/usr/bin/bash
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,29 @@
+# Docker container for Alles production
+
+These scripts build the Alles firmwware in a container, using a fully isloated
+ESP-IDF toolchain.
+
+To build it, you'll need a Linux computer with [Docker](https://docs.docker.com/engine/install/ubuntu/) installed. Any OS capable of running Docker can work to build the image, however a Linux-based system is required to flash devices through the container.
+
+You will aslo need make and git; you can install them on Ubuntu like so:
+
+    sudo apt update
+    sudo apt install build-essential git
+
+Once you have these prerequisites, clone the repository, then build the Docker image:
+
+    git clone https://github.com/blinkinlabs/alles.git
+    cd alles/docker
+    make build-docker
+
+This will take a little while. Once it is done, you can build the firmware in the container:
+
+    make build
+
+Once the firmware is built, flash an attached Alles device:
+
+    make flash
+
+Note: The above assumes that the USB-to-serial converter in the Alles was detected as /dev/ttyUSB0; if it was mounted somewhere else, you can specify the position:
+
+    PORT=/dev/ttyXXXX make flash


### PR DESCRIPTION
This commit adds a docker-based script for programming fresh Alles PCBs from an isolated build environment. It's intended to be run on a Linux-based host, so that the serial device can be passed into the container.